### PR TITLE
Add item management

### DIFF
--- a/src/ansys/grantami/recordlists/_connection.py
+++ b/src/ansys/grantami/recordlists/_connection.py
@@ -50,8 +50,7 @@ class RecordListApiClient(ApiClient):
         """
 
         return RecordList.from_model(
-            self,
-            self.list_management_api.api_v1_lists_list_list_identifier_get(identifier)
+            self, self.list_management_api.api_v1_lists_list_list_identifier_get(identifier)
         )
 
     def get_list_items(self, identifier: str) -> List[RecordListItem]:
@@ -76,7 +75,7 @@ class RecordListApiClient(ApiClient):
             identifier,
             body=models.GrantaServerApiListsDtoRecordListItems(
                 items=[item.to_model() for item in items]
-            )
+            ),
         )
 
     def remove_items_from_list(self, identifier: str, items: List[RecordListItem]):
@@ -92,7 +91,7 @@ class RecordListApiClient(ApiClient):
             identifier,
             body=models.GrantaServerApiListsDtoRecordListItems(
                 items=[item.to_model() for item in items]
-            )
+            ),
         )
 
 

--- a/src/ansys/grantami/recordlists/models.py
+++ b/src/ansys/grantami/recordlists/models.py
@@ -35,7 +35,7 @@ class RecordList:
         published: bool,
         awaiting_approval: bool,
         # internal_use=None,
-        items: Optional[List["RecordListItem"]] = None
+        items: Optional[List["RecordListItem"]] = None,
     ):
         self._client = client
         self._identifier: str = identifier
@@ -98,7 +98,7 @@ class RecordList:
     def add_items(self, items: List["RecordListItem"]):
         """
         Add items to the RecordList and refreshes all items.
-        Might be succesful even if the items are invalid references.
+        Might be successful even if the items are invalid references.
         """
         self._client.add_items_to_list(self._identifier, items)
         self.read_items()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import pytest
 
 from ansys.grantami.recordlists._connection import RecordListApiClient
 from ansys.grantami.recordlists.models import RecordListItem
-from ansys.grantami.serverapi_openapi.api import ListManagementApi, ListItemApi, ListPermissionsApi
+from ansys.grantami.serverapi_openapi.api import ListManagementApi, ListItemApi
 from ansys.grantami.serverapi_openapi.models import (
     GrantaServerApiListsDtoRecordListHeader,
     GrantaServerApiListsDtoRecordListItems,
@@ -27,9 +27,7 @@ class TestClientMethod:
     @pytest.fixture
     def api_method(self, monkeypatch):
         mocked_method = Mock(return_value=self._return_value)
-        monkeypatch.setattr(
-            self._api, self._api_method, mocked_method
-        )
+        monkeypatch.setattr(self._api, self._api_method, mocked_method)
         return mocked_method
 
 
@@ -81,9 +79,7 @@ class TestAddItems(TestClientMethod):
     _api = ListItemApi
     _api_method = "api_v1_lists_list_list_identifier_items_add_post"
 
-    @pytest.mark.parametrize("items", [
-        None, [], set()
-    ])
+    @pytest.mark.parametrize("items", [None, [], set()])
     def test_add_no_items(self, client, api_method, items):
         identifier = "00000-0000a"
         response = client.add_items_to_list(identifier, items)
@@ -95,14 +91,14 @@ class TestAddItems(TestClientMethod):
         identifier = "00000-0000a"
         items = [RecordListItem("a", "b", "c")]
         expected_body = GrantaServerApiListsDtoRecordListItems(
-                items=[
-                    GrantaServerApiListsDtoListItem(
-                        database_guid="a",
-                        table_guid="b",
-                        record_history_guid="c",
-                    )
-                ]
-            )
+            items=[
+                GrantaServerApiListsDtoListItem(
+                    database_guid="a",
+                    table_guid="b",
+                    record_history_guid="c",
+                )
+            ]
+        )
 
         response = client.add_items_to_list(identifier, items)
 
@@ -115,9 +111,7 @@ class TestRemoveItems(TestClientMethod):
     _api = ListItemApi
     _api_method = "api_v1_lists_list_list_identifier_items_remove_post"
 
-    @pytest.mark.parametrize("items", [
-        None, [], set()
-    ])
+    @pytest.mark.parametrize("items", [None, [], set()])
     def test_remove_no_items(self, client, api_method, items):
         identifier = "00000-0000a"
         response = client.remove_items_from_list(identifier, items)
@@ -129,14 +123,14 @@ class TestRemoveItems(TestClientMethod):
         identifier = "00000-0000a"
         items = [RecordListItem("a", "b", "c")]
         expected_body = GrantaServerApiListsDtoRecordListItems(
-                items=[
-                    GrantaServerApiListsDtoListItem(
-                        database_guid="a",
-                        table_guid="b",
-                        record_history_guid="c",
-                    )
-                ]
-            )
+            items=[
+                GrantaServerApiListsDtoListItem(
+                    database_guid="a",
+                    table_guid="b",
+                    record_history_guid="c",
+                )
+            ]
+        )
 
         response = client.remove_items_from_list(identifier, items)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,6 @@ from ansys.grantami.recordlists.models import RecordList, RecordListItem
 
 
 class TestRecordList:
-
     @pytest.fixture
     def mock_client(self):
         return Mock(spec=RecordListApiClient)
@@ -29,13 +28,7 @@ class TestRecordList:
         assert mock_client.get_list_items.called_once_with("00000")
 
     items_variations = pytest.mark.parametrize(
-        "items",
-        [
-            [],
-            None,
-            ["1", 2],
-            [RecordListItem("db", "table", "record")]
-        ]
+        "items", [[], None, ["1", 2], [RecordListItem("db", "table", "record")]]
     )
 
     @items_variations
@@ -47,4 +40,3 @@ class TestRecordList:
     def test_remove_items(self, mock_client, record_list, items):
         record_list.add_items([])
         assert mock_client.add_items_to_list.called_once_with([])
-


### PR DESCRIPTION
This PRs adds a couple things:
- Client now includes methods to manage list items
- RecordList (previously RecordListHeader) now includes methods so that users can interact with the list directly rather than through the client, e.g. 
```
record_list = client.get_list(my_id)
record_list.add_items([....])
```