### PR TITLE
Maintenance - fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,6 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
 ansys-openapi-common = "^1.2.0"
-ansys-grantami-serverapi-openapi = "0.1.0.dev12"
-
-[tool.poetry.group.temp]
-
-[tool.poetry.group.temp.dependencies]
 ansys-grantami-serverapi-openapi = {path = "deps/ansys_grantami_serverapi_openapi-0.1.0.dev12-py3-none-any.whl"}
 
 # Optional documentation dependencies


### PR DESCRIPTION
Add the missing dependency on openapi-common (was always installed due to the dependency on serverapi-openapi)
~~Duplicate the serverapi-openapi dependency:~~
~~- versioned for the real package dependencies~~
~~- as path for build, test, docs workflows to continue successfully resolving the dependency~~

~~This should make it possible for the resulting wheel to be installed with:~~
~~```pip install ansys_grantami_recordlists-0.1.dev0-py3-none-any --find-links=<path to folder with serverapi-openapi>```~~

This is not defining the dependency twice anymore: it works well for local installation, but breaks the use of pyansys/actions/build-wheelhouse and therefore smoketests in CI. (which uses `pip install .`)
The problem will go away once `serverapi-openapi` is published, and in the meantime it's still possible to install the package locally by using `pip install <path.whl> --no-deps` and installing  `serverapi-openapi` manually from its wheel.
