### PR TITLE
FIX: ensure DOCUMENTATION_CNAME is passed to server_checks.yml

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,7 +21,7 @@ html_theme = "ansys_sphinx_theme"
 html_short_title = html_title = "Granta MI RecordLists"
 html_favicon = ansys_favicon
 
-cname = os.getenv("DOCUMENTATION_CNAME", "<DEFAULT_CNAME>")
+cname = os.getenv("DOCUMENTATION_CNAME", "recordlists.grantami.docs.pyansys.com")
 """The canonical name of the webpage hosting the documentation."""
 
 # specify the location of your github repo


### PR DESCRIPTION
This pull-request fixes the issue found in [this line](https://github.com/pyansys/grantami-recordlists/blob/gh-pages/version/dev/index.html#L58) where the CNAME is not captured.

The reason is that the `server_checks.yml` does not have access to this environment variable when building the documentation.