### PR TITLE
Maintenance - Add docs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
    :alt: Codecov
 
 .. |GH-CI| image:: https://github.com/pyansys/grantami-recordlists/actions/workflows/ci_cd.yml/badge.svg
-   :target: https://github.com/pyansys/grantami-recordlists/actions/workflows/ci_cd.yml
+   :target: https://github.com/ansys/grantami-recordlists/actions/workflows/ci_cd.yml
    :alt: GH-CI
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
@@ -68,19 +68,19 @@ this code:
     pip install ansys-grantami-recordlists
 
 
-Alternatively, to install the latest from ``ansys-grantami-recordlists`` `GitHub <https://github.com/pyansys/grantami-recordlists>`_,
+Alternatively, to install the latest from ``ansys-grantami-recordlists`` `GitHub <https://github.com/ansys/grantami-recordlists>`_,
 use this code:
 
 .. code::
 
-    pip install git:https://github.com/pyansys/grantami-recordlists.git
+    pip install git:https://github.com/ansys/grantami-recordlists.git
 
 
 To install a local *development* version with Git and Poetry, use this code:
 
 .. code::
 
-    git clone https://github.com/pyansys/grantami-recordlists
+    git clone https://github.com/ansys/grantami-recordlists
     cd grantami-recordlists
     poetry install
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ cname = os.getenv("DOCUMENTATION_CNAME", "recordlists.grantami.docs.pyansys.com"
 
 # specify the location of your github repo
 html_theme_options = {
-    "github_url": "https://github.com/pyansys/grantami-recordlists",
+    "github_url": "https://github.com/ansys/grantami-recordlists",
     "show_prev_next": False,
     "show_breadcrumbs": True,
     "additional_breadcrumbs": [

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -39,7 +39,7 @@ dependencies to run the tests, build the docs and build the package.
 
 .. code:: bash
 
-    git clone https://github.com/pyansys/grantami-recordlists
+    git clone https://github.com/ansys/grantami-recordlists
     cd grantami-recordlists
     poetry install --with build,doc,tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 readme = "README.rst"
-repository = "https://github.com/pyansys/grantami-recordlists"
+repository = "https://github.com/ansys/grantami-recordlists"
 documentation = "https://recordlists.grantami.docs.pyansys.com"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 readme = "README.rst"
 repository = "https://github.com/pyansys/grantami-recordlists"
+documentation = "https://recordlists.grantami.docs.pyansys.com"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Add link to documentation in pyproject.toml
Update links to repo with the new org name: this isn't necessary as there is a redirect, but the links might as well be correct