### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -104,10 +104,10 @@ jobs:
 
       - name: "Install Python dependencies"
         run: |
-          python -m pip install --upgrade pip poetry tox tox-gh-actions
+          python -m pip install --upgrade pip poetry tox
 
       - name: "Test with tox"
-        run: tox -- -m "not integration"
+        run: tox -e tests -- -m "not integration"
 
       - name: "Upload coverage results"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: "Install Python dependencies"
         run: |
-          python -m pip install --upgrade pip poetry tox tox-gh-actions
+          python -m pip install --upgrade pip poetry tox
 
       - name: "Test with tox"
         run: tox -- -m "not integration"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: "Install Python dependencies"
         run: |
-          python -m pip install --upgrade pip poetry tox
+          python -m pip install --upgrade pip poetry tox tox-gh-actions
 
       - name: "Test with tox"
         run: tox -- -m "not integration"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -148,6 +148,11 @@ jobs:
 
       - name: "Build PDF documentation"
         run: poetry run -- make -C doc latexpdf
+        env:
+          TEST_SL_URL: ${{secrets.TEST_SERVER_URL}}
+          TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
+          TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
+          BUILD_EXAMPLES: "true"
 
       - name: "Upload HTML documentation"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -106,7 +106,7 @@ jobs:
           pip install poetry 'tox<4' --disable-pip-version-check
 
       - name: "Test with tox (integration tests only)"
-        run: tox -e py310 -- -m "integration"
+        run: tox -e tests -- -m "integration"
         env:
           TEST_SL_URL: ${{secrets.TEST_SERVER_URL}}
           TEST_LIST_ADMIN_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -106,7 +106,7 @@ jobs:
           pip install poetry 'tox<4' --disable-pip-version-check
 
       - name: "Test with tox (integration tests only)"
-        run: tox -- -m "integration"
+        run: tox -e py310 -- -m "integration"
         env:
           TEST_SL_URL: ${{secrets.TEST_SERVER_URL}}
           TEST_LIST_ADMIN_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -144,7 +144,7 @@ jobs:
           TEST_SL_URL: ${{secrets.TEST_SERVER_URL}}
           TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
-          BUILD_EXAMPLES: 1
+          BUILD_EXAMPLES: "true"
 
       - name: "Build PDF documentation"
         run: poetry run -- make -C doc latexpdf

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -106,7 +106,7 @@ jobs:
           pip install poetry 'tox<4' --disable-pip-version-check
 
       - name: "Test with tox (integration tests only)"
-        run: tox -e py39 -- -m "integration"
+        run: tox -- -m "integration"
         env:
           TEST_SL_URL: ${{secrets.TEST_SERVER_URL}}
           TEST_LIST_ADMIN_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -185,6 +185,9 @@ exclude_patterns = []
 EXAMPLES_SOURCE_DIR = Path(__file__).parent.parent.parent.absolute() / "examples"
 EXAMPLES_OUTPUT_DIR = Path(__file__).parent.absolute() / "examples"
 BUILD_EXAMPLES = True if os.environ.get("BUILD_EXAMPLES", "false") == "true" else False
+if BUILD_EXAMPLES:
+    ipython_dir = Path("../../.ipython").absolute()
+    os.environ["IPYTHONDIR"] = str(ipython_dir)
 
 ignore_example_files = r"test.*" if BUILD_EXAMPLES else r"^(?!test)"
 

--- a/examples/01_publishing_revising_withdrawing.py
+++ b/examples/01_publishing_revising_withdrawing.py
@@ -24,7 +24,7 @@
 # ## Connect to Granta MI and create a record list
 
 # Import the ``Connection`` class and create the connection. See the
-# [Getting started](00_Basic_usage.ipynb) example for more details.
+# [Getting started](00_basic_usage.ipynb) example for more details.
 
 # + tags=[]
 from ansys.grantami.recordlists import Connection

--- a/examples/02_searching.py
+++ b/examples/02_searching.py
@@ -23,7 +23,7 @@
 # ## Connect to Granta MI and create a record list
 
 # Import the ``Connection`` class and create the connection. See the
-# [Getting started](00_Basic_usage.ipynb) example for more details.
+# [Getting started](00_basic_usage.ipynb) example for more details.
 
 # + tags=[]
 from ansys.grantami.recordlists import (
@@ -46,7 +46,7 @@ client = connection.connect()
 # * ``identifier_d``: Unpublished
 #
 # See the
-# [Publishing, revising, and withdrawing record lists](01_Publishing_revising_withdrawing.ipynb)
+# [Publishing, revising, and withdrawing record lists](01_publishing_revising_withdrawing.ipynb)
 # example for more details.
 
 # + tags=[]

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ allowlist_externals =
     poetry
 commands =
     poetry install --with doc
-    poetry run sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -W -bhtml -n --keep-going
+    poetry run sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/html" --color -W -bhtml -n --keep-going


### PR DESCRIPTION
Addresses a couple of issues with the docs in CI:
- Examples were not run and mock examples were generated instead
- Mock examples artifact was not uploaded because of path issue
- PDF docs didn't include examples

In this state, this would run the examples twice, once for HTML docs and once for PDF docs. We should find a way to only run them once.

Also includes a fix for the unit test and integration test steps: now calls `tox -e tests` to run the default tox env, which will default to the python interpreter used in tox.