### PR TITLE
Skip coverage uploads for dependabot PRs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: "Upload coverage artifacts"
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION  && matrix.os == 'ubuntu-latest'}}
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' and !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
         with:
           name: coverage-html-unittests
           path: .cov/html
@@ -119,7 +119,7 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
-        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION  && matrix.os == 'ubuntu-latest'}}
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION  && matrix.os == 'ubuntu-latest' and !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
         with:
           files: .cov/xml
           flags: unittests

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: "Upload coverage artifacts"
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' and !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
         with:
           name: coverage-html-unittests
           path: .cov/html
@@ -119,7 +119,7 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v3
-        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION  && matrix.os == 'ubuntu-latest' and !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
         with:
           files: .cov/xml
           flags: unittests


### PR DESCRIPTION
PRs triggered by dependabot events seem to be failing to upload the coverage artifacts to codecov. This PR skips these steps for jobs triggered by a dependabot event.

I think this change is ok: code coverage should generally be unaffected by a dependency change anyway.