### PR TITLE
Add release.yml configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 documentation:
 - changed-files:
-  - any-glob-to-any-file: ['doc/source/**/*']
+  - any-glob-to-any-file: ['doc/source/**/*', 'examples/**/*']
 maintenance:
 - changed-files:
   - any-glob-to-any-file: ['.github/**/*', '.flake8', 'pyproject.toml']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: "What's changed"
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: "Dependencies"
+      labels:
+        - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,7 +9,7 @@ changelog:
     - title: "Documentation"
       labels:
         - documentation
-    - title: "Maintenance & dependencies"
+    - title: "Maintenance"
       labels:
         - maintenance
-        - dependencies
+

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,11 +1,15 @@
 changelog:
+  exclude:
+    labels:
+      - dependencies
   categories:
-    - title: "What's changed"
+    - title: "Features"
       labels:
-        - '*'
-      exclude:
-        labels:
-          - dependencies
-    - title: "Dependencies"
+        - enhancement
+    - title: "Documentation"
       labels:
+        - documentation
+    - title: "Maintenance & dependencies"
+      labels:
+        - maintenance
         - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,4 +12,6 @@ changelog:
     - title: "Maintenance"
       labels:
         - maintenance
-
+    - title: "Other changes"
+      labels:
+        - "*"


### PR DESCRIPTION
Add a config file for auto-generated release notes.

This completely excludes PRs flagged only as `dependencies`. Any dependency bump in the pyproject.toml is labeled as `maintenance`, so we would still list dependency version bumps, just not updates of the lock file.

I'll add a comment with the autogenerated release notes if we were to release this PR branch (diff with 1.0).