### PR TITLE
chore: skip local hooks for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [mypy-code]
+
 repos:
 
 - repo: https://github.com/psf/black


### PR DESCRIPTION
As title says. Also adding pre-commit.ci badge to main README