### PR TITLE
CI: Skip stable doc deployment on non-final releases

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -179,7 +179,7 @@ jobs:
     name: "Deploy stable documentation"
     runs-on: ubuntu-latest
     needs: release
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && !contains(github.ref, `a`) && !contains(github.ref, `b`)  && !contains(github.ref, `rc`) && !contains(github.ref, `post`)
     steps:
       - uses: ansys/actions/doc-deploy-stable@v5
         with:


### PR DESCRIPTION
To prevent failures when CI is triggered by tags.
The doc deploy action does not yet support pre- or post-releases