### PR TITLE
Disable codecov upload

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,13 +117,13 @@ jobs:
           path: .cov/html
           retention-days: 7
 
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v3
-        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
-        with:
-          files: .cov/xml
-          flags: unittests
-          fail_ci_if_error: true
+#      - name: "Upload coverage to Codecov"
+#        uses: codecov/codecov-action@v3
+#        if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.os == 'ubuntu-latest' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+#        with:
+#          files: .cov/xml
+#          flags: unittests
+#          fail_ci_if_error: true
 
   build-library:
     name: "Build library"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -130,13 +130,13 @@ jobs:
           path: .cov/html
           retention-days: 7
 
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v3
-        if: ${{ matrix.os  == 'ubuntu-latest' }}
-        with:
-          files: .cov/xml
-          flags: integration
-          fail_ci_if_error: true
+#      - name: "Upload coverage to Codecov"
+#        uses: codecov/codecov-action@v3
+#        if: ${{ matrix.os  == 'ubuntu-latest' }}
+#        with:
+#          files: .cov/xml
+#          flags: integration
+#          fail_ci_if_error: true
 
   doc-build:
     name: "Build documentation"


### PR DESCRIPTION
Current builds are failing because of codecov issues. Disabling the workflow step to get CI unblocked.