### PR TITLE
CI - skip vm management if active runs

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -197,11 +197,15 @@ jobs:
           path: doc/_build/latex/*.pdf
           retention-days: 7
 
+  check_workflow_runs:
+    needs: doc-build
+    uses: ansys/grantami-bomanalytics/.github/workflows/check-concurrent-workflows.yml
+
   stop-vm:
     name: "Stop Azure VM"
     runs-on: ubuntu-latest
-    needs: doc-build
-    if: ${{ always() && !(inputs.skip-vm-management)}}
+    needs: check_workflow_runs
+    if: always() && !cancelled() && !(inputs.skip-vm-management) && needs.check_workflow_runs.outputs.active-runs != 'true'
     steps:
       - uses: azure/CLI@v2
         with:

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -199,7 +199,7 @@ jobs:
 
   check_workflow_runs:
     needs: doc-build
-    uses: ansys/grantami-bomanalytics/.github/workflows/check-concurrent-workflows.yml
+    uses: ansys/grantami-bomanalytics/.github/workflows/check-concurrent-workflows.yml@main
 
   stop-vm:
     name: "Stop Azure VM"


### PR DESCRIPTION
Use the workflow defined in Bomanalytics to skip VM management if there are any active workflows among the workflows listed in the action