### PR TITLE
Remove vale version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -35,7 +35,6 @@ jobs:
       - uses: ansys/actions/doc-style@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vale-version: "2.29.6"
 
   doc-build:
     name: "Build documentation (mock examples)"


### PR DESCRIPTION
Remove explicit vale version from the workflow definition, which should result in falling back to the default defined in the action