### PR TITLE
Use ansys doc build action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -38,36 +38,23 @@ jobs:
           vale-version: "2.29.6"
 
   doc-build:
-    name: "Build documentation (mock examples)"
+    name: Documentation Build (mock examples)
     runs-on: ubuntu-latest
-    needs: doc-style
     steps:
-      - name: "Checkout the repository"
-        uses: actions/checkout@v4
+    - name: "Run Ansys documentation building action"
+      uses: ansys/actions/doc-build@v6
+      with:
+        check-links: false
+        dependencies: "pandoc"
+        sphinxopts: "-j 1 -n -W --keep-going"
 
-      - name: "Set up Python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-      - name: "Install system dependencies"
-        run: |
-          sudo apt-get update && sudo apt-get install pandoc
-
-      - name: "Install Python dependencies"
-        run: |
-          python -m pip install --upgrade pip tox
-          python -m pip install poetry~=1.4.0
-
-      - name: "Generate the documentation with tox"
-        run: tox -e doc
-
-      - name: "Upload HTML documentation"
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-html-mock-examples
-          path: doc/_build/html
-          retention-days: 7
+    - name: "Delete unneeded doc artifact"
+      if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+      uses: geekyeggo/delete-artifact@v5
+      with:
+        name: |
+          documentation-html
+          documentation-pdf
 
   smoke-tests:
     name: "Build wheelhouse for latest Python versions"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -148,54 +148,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     steps:
-      - name: "Checkout the repository"
-        uses: actions/checkout@v4
-
-      - name: "Set up Python ${{ inputs.python-version }}"
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
-
-      - name: "Install system dependencies"
-        run: |
-          sudo apt update
-          sudo apt-get install pandoc
-          sudo apt-get install texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
-
-      - name: "Install documentation dependencies"
-        run: |
-          pip install poetry~=1.3.0 --disable-pip-version-check
-          poetry install --with doc
-
-      - name: "Build HTML documentation"
-        run: poetry run -- make -C doc html SPHINXOPTS="-n -W --keep-going"
+      - name: "Run Ansys documentation building action"
+        uses: ansys/actions/doc-build@v6
         env:
           TEST_SL_URL: ${{secrets.TEST_SERVER_URL_NEXT}}
           TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
           TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
           BUILD_EXAMPLES: "true"
-
-      - name: "Build PDF documentation"
-        run: poetry run -- make -C doc latexpdf
-        env:
-          TEST_SL_URL: ${{secrets.TEST_SERVER_URL_NEXT}}
-          TEST_USER: ${{secrets.TEST_SERVER_ADMIN_USER}}
-          TEST_PASS: ${{secrets.TEST_SERVER_ADMIN_PASS}}
-          BUILD_EXAMPLES: "true"
-
-      - name: "Upload HTML documentation"
-        uses: actions/upload-artifact@v4
         with:
-          name: documentation-html
-          path: doc/_build/html
-          retention-days: 7
-
-      - name: "Upload PDF documentation"
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-pdf
-          path: doc/_build/latex/*.pdf
-          retention-days: 7
+          check-links: false
+          dependencies: "pandoc"
+          sphinxopts: "-j 1 -n -W --keep-going"
 
   check_workflow_runs:
     name: Check if there are active workflow runs

--- a/doc/changelog.d/248.changed.md
+++ b/doc/changelog.d/248.changed.md
@@ -1,0 +1,1 @@
+Use ansys doc build action


### PR DESCRIPTION
Closes #224

Use the re-usable ansys doc-build actions, and selectively delete the unneeded artifact if the CI will generate a full docs artifact. Copied the implementation from grantami-jobqueue.

Documentation check will fail until #246 is merged