### PR TITLE
Exclude table with dynamic record count from tests

### DIFF
--- a/doc/changelog.d/251.fixed.md
+++ b/doc/changelog.d/251.fixed.md
@@ -1,0 +1,1 @@
+Exclude table with dynamic record count from tests

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -169,7 +169,12 @@ def design_data_table_guid(admin_client) -> str:
 @pytest.fixture(scope="session")
 def resolvable_items(admin_client, training_database_guid) -> List[RecordListItem]:
     """Get all records in the MI_Training database and use them to create
-    a list of RecordListItems which can be added to a list."""
+    a list of RecordListItems which can be added to a list.
+
+    Exclude records in the 'Tensile Test Data' table, since this is used in the
+    grantami-jobqueue integration tests, and the changing contents of the table
+    can cause test failures.
+    """
     search_api = SearchApi(admin_client)
 
     is_any_record_type = GrantaServerApiSearchRecordPropertyCriterion(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,10 +26,13 @@ import uuid
 
 from ansys.grantami.serverapi_openapi.api import SchemaDatabasesApi, SchemaTablesApi, SearchApi
 from ansys.grantami.serverapi_openapi.models import (
+    GrantaServerApiSearchBooleanCriterion,
     GrantaServerApiSearchDiscreteTextValuesDatumCriterion,
     GrantaServerApiSearchRecordPropertyCriterion,
     GrantaServerApiSearchSearchableRecordProperty,
     GrantaServerApiSearchSearchRequest,
+    GrantaServerApiSearchShortTextDatumCriterion,
+    GrantaServerApiSearchTextMatchBehavior,
     GrantaServerApiVersionState,
 )
 from common import DB_KEY, TABLE_NAME, RecordCreator
@@ -168,12 +171,25 @@ def resolvable_items(admin_client, training_database_guid) -> List[RecordListIte
     """Get all records in the MI_Training database and use them to create
     a list of RecordListItems which can be added to a list."""
     search_api = SearchApi(admin_client)
+
+    is_any_record_type = GrantaServerApiSearchRecordPropertyCriterion(
+        _property=GrantaServerApiSearchSearchableRecordProperty.RECORDTYPE,
+        inner_criterion=GrantaServerApiSearchDiscreteTextValuesDatumCriterion(
+            any=["Record", "Generic", "Folder"],
+        ),
+    )
+    is_in_tensile_test_data_table = GrantaServerApiSearchRecordPropertyCriterion(
+        _property=GrantaServerApiSearchSearchableRecordProperty.TABLENAME,
+        inner_criterion=GrantaServerApiSearchShortTextDatumCriterion(
+            text_match_behavior=GrantaServerApiSearchTextMatchBehavior.EXACTMATCH,
+            value="Tensile Test Data",
+        ),
+    )
+
     search_body = GrantaServerApiSearchSearchRequest(
-        criterion=GrantaServerApiSearchRecordPropertyCriterion(
-            _property=GrantaServerApiSearchSearchableRecordProperty.RECORDTYPE,
-            inner_criterion=GrantaServerApiSearchDiscreteTextValuesDatumCriterion(
-                any=["Record", "Generic", "Folder"],
-            ),
+        criterion=GrantaServerApiSearchBooleanCriterion(
+            all=[is_any_record_type],
+            _none=[is_in_tensile_test_data_table],
         )
     )
     search_results = search_api.database_search(


### PR DESCRIPTION
Closes #242

To avoid tests failing when run concurrently with jobqueue tests, filter out records from the 'Tensile test data' table.

I did initially think about using the 'Restricted Substances' database from bomanalytics, but then we'd be using two separate databases: one for the bulk resolvability checks, and one for checking individual records in different states. This way we leave the RS database alone and confine the record creation to the Training database.

This means our bulk resolvability tests will be operating over ~200 fewer records, but we're still up near 1000 records, so I think it's still a good test.

The coupling between the test templates in jobqueue and the tests here also isn't ideal, but I don't really see an alternative.