### PR TITLE
Update openapi-common reference link

### DIFF
--- a/doc/changelog.d/256.miscellaneous.md
+++ b/doc/changelog.d/256.miscellaneous.md
@@ -1,1 +1,1 @@
-Update openapi-common intersphinx link
+Update openapi-common reference link

--- a/doc/changelog.d/256.miscellaneous.md
+++ b/doc/changelog.d/256.miscellaneous.md
@@ -1,0 +1,1 @@
+Update openapi-common intersphinx link

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -62,15 +62,8 @@ autodoc_member_order = "bysource"
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "openapi-common": ("https://openapi.docs.pyansys.com", None),
+    "openapi-common": ("https://openapi.docs.pyansys.com/version/stable", None),
     "requests": ("https://requests.readthedocs.io/en/latest/", None),
-    # kept here as an example
-    # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    # "numpy": ("https://numpy.org/devdocs", None),
-    # "matplotlib": ("https://matplotlib.org/stable", None),
-    # "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    # "pyvista": ("https://docs.pyvista.org/", None),
-    # "grpc": ("https://grpc.github.io/grpc/python/", None),
 }
 
 # numpydoc configuration


### PR DESCRIPTION
Changes to doc deployment in openapi-common for multiversion support changed the location of the object inventory. Use `/version/stable` in intersphinx config.