### PR TITLE
Only run labeler workflow on pull requests

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -29,6 +29,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
 
     - name: Label based on changed files and branch name

--- a/doc/changelog.d/260.changed.md
+++ b/doc/changelog.d/260.changed.md
@@ -1,0 +1,1 @@
+Only run labeler workflow on pull requests


### PR DESCRIPTION
Closes #257 

Previously, if the labels.yml file was updated and merged to main, the entire workflow would run. Now, only the label-syncer job will run. The others will be filtered out by conditionals or dependencies.