### PR TITLE
Don't generate changelog fragments for dependabot PRs

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -59,6 +59,7 @@ jobs:
         contents: write
         pull-requests: write
       runs-on: ubuntu-latest
+      if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
       steps:
       - uses: ansys/actions/doc-changelog@v6
         with:

--- a/doc/changelog.d/266.changed.md
+++ b/doc/changelog.d/266.changed.md
@@ -1,0 +1,1 @@
+Don't generate changelog fragments for dependabot PRs


### PR DESCRIPTION
Closes #265 

Skips generation of changelog fragments for dependabot PRs