### PR TITLE
Publish dev builds to private PyPI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,6 +7,14 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish-to-private-pypi:
+        description: Whether to publish the build to the private PyPI
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'false'
 
 env:
   MAIN_PYTHON_VERSION: '3.9'
@@ -149,7 +157,7 @@ jobs:
     name: "Publish dev build to private PyPI"
     runs-on: ubuntu-latest
     needs: [ server-checks ]
-    if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
+    if: (github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main') && (inputs.publish-to-private-pypi == 'true')
     steps:
       - name: "Release to private PyPI"
         uses: ansys/actions/release-pypi-private@v7

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -145,6 +145,19 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           doc-artifact-name: documentation-html
 
+  release-private-pypi:
+    name: "Publish dev build to private PyPI"
+    runs-on: ubuntu-latest
+    needs: [ server-checks ]
+    if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
+    steps:
+      - name: "Release to private PyPI"
+        uses: ansys/actions/release-pypi-private@v7
+        with:
+          library-name: ${{ env.LIBRARY_NAME }}
+          twine-username: "__token__"
+          twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
+
   update-changelog:
     name: "Update CHANGELOG for new tag"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')

--- a/doc/changelog.d/318.maintenance.md
+++ b/doc/changelog.d/318.maintenance.md
@@ -1,0 +1,1 @@
+Publish dev builds to private PyPI


### PR DESCRIPTION
Adds an input to CI workflow to publish builds to the private PyPI.
Publishing after every push to main would be problematic without some kind of automated management of build numbers. We don't anticipate many iterations here and `poetry version` does not yet support bumping dev builds, so this makes it a deliberate action to publish it to the private index.

The build will only be published if the workflow is manually triggered on the main branch and the input explicitly set to true.