### PR TITLE
Use PyPI Trusted Publisher approach for releases

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -186,13 +186,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-library, server-checks, update-changelog]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: ansys/actions/release-pypi-public@v7
         name: "Release to public PyPI"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          use-trusted-publisher: true
 
       - uses: ansys/actions/release-github@v7
         name: "Release to GitHub"

--- a/doc/changelog.d/320.maintenance.md
+++ b/doc/changelog.d/320.maintenance.md
@@ -1,0 +1,1 @@
+Use trusted publisher

--- a/doc/changelog.d/320.maintenance.md
+++ b/doc/changelog.d/320.maintenance.md
@@ -1,1 +1,1 @@
-Use trusted publisher
+Use PyPI Trusted Publisher approach for releases


### PR DESCRIPTION
Closes #279 

Use trusted publisher approach for release.

- [x] `release` environment existed already
- [x] Repository authorized to use trusted publisher approach