### PR TITLE
Add link to supported authentication schemes

### DIFF
--- a/doc/changelog.d/321.documentation.md
+++ b/doc/changelog.d/321.documentation.md
@@ -1,0 +1,1 @@
+Add link to supported authentication schemes

--- a/doc/source/api/connection.rst
+++ b/doc/source/api/connection.rst
@@ -3,6 +3,8 @@
 Granta MI connection
 ====================
 
+The OpenAPI-Common documentation lists supported `Authentication schemes <https://openapi.docs.pyansys.com/version/stable/index.html#authentication-schemes>`_.
+
 Connection builder
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/api/connection.rst
+++ b/doc/source/api/connection.rst
@@ -3,8 +3,6 @@
 Granta MI connection
 ====================
 
-The OpenAPI-Common documentation lists supported `Authentication schemes <https://openapi.docs.pyansys.com/version/stable/index.html#authentication-schemes>`_.
-
 Connection builder
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 import shutil
 
+from ansys.openapi.common import __version__ as openapi_common_version
 from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 import jupytext
 
@@ -61,11 +62,31 @@ autodoc_typehints = "description"  # Remove typehints from signatures in docs
 autodoc_typehints_description_target = "documented"
 autodoc_member_order = "bysource"
 
+from packaging.version import parse as parse_version
+
+openapi_common_version = parse_version(openapi_common_version)
+OPENAPI_COMMON_DOCS_BASE_URL = "https://openapi.docs.pyansys.com/version/"
+if openapi_common_version.is_prerelease:
+    OPENAPI_COMMON_DOCS_URL = OPENAPI_COMMON_DOCS_BASE_URL + "dev"
+else:
+    OPENAPI_COMMON_DOCS_URL = (
+        OPENAPI_COMMON_DOCS_BASE_URL
+        + f"{openapi_common_version.major}.{openapi_common_version.minor}"
+    )
+
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "openapi-common": ("https://openapi.docs.pyansys.com/version/stable", None),
+    "openapi-common": (OPENAPI_COMMON_DOCS_URL, None),
     "requests": ("https://requests.readthedocs.io/en/latest/", None),
+}
+
+extlinks = {
+    "MI_docs": (
+        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
+        None,
+    ),
+    "OpenAPI-Common": (f"{OPENAPI_COMMON_DOCS_URL}/%s", None),
 }
 
 # numpydoc configuration
@@ -89,14 +110,6 @@ numpydoc_validation_checks = {
     # "SS05", # Summary must start with infinitive verb, not third person
     "RT02",  # The first line of the Returns section should contain only the
     # type, unless multiple values are being returned"
-}
-
-extlinks = {
-    "MI_docs": (
-        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
-        None,
-    ),
-    "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None)
 }
 
 # static path

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import re
 import shutil
 
-from ansys.openapi.common import __version__ as openapi_common_version
 from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 import jupytext
 
@@ -62,31 +61,11 @@ autodoc_typehints = "description"  # Remove typehints from signatures in docs
 autodoc_typehints_description_target = "documented"
 autodoc_member_order = "bysource"
 
-from packaging.version import parse as parse_version
-
-openapi_common_version = parse_version(openapi_common_version)
-OPENAPI_COMMON_DOCS_BASE_URL = "https://openapi.docs.pyansys.com/version/"
-if openapi_common_version.is_prerelease:
-    OPENAPI_COMMON_DOCS_URL = OPENAPI_COMMON_DOCS_BASE_URL + "dev"
-else:
-    OPENAPI_COMMON_DOCS_URL = (
-        OPENAPI_COMMON_DOCS_BASE_URL
-        + f"{openapi_common_version.major}.{openapi_common_version.minor}"
-    )
-
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "openapi-common": (OPENAPI_COMMON_DOCS_URL, None),
+    "openapi-common": ("https://openapi.docs.pyansys.com/version/stable", None),
     "requests": ("https://requests.readthedocs.io/en/latest/", None),
-}
-
-extlinks = {
-    "MI_docs": (
-        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
-        None,
-    ),
-    "OpenAPI-Common": (f"{OPENAPI_COMMON_DOCS_URL}/%s", None),
 }
 
 # numpydoc configuration
@@ -110,6 +89,14 @@ numpydoc_validation_checks = {
     # "SS05", # Summary must start with infinitive verb, not third person
     "RT02",  # The first line of the Returns section should contain only the
     # type, unless multiple values are being returned"
+}
+
+extlinks = {
+    "MI_docs": (
+        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
+        None,
+    ),
+    "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None)
 }
 
 # static path

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -96,7 +96,7 @@ extlinks = {
         "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
         None,
     ),
-    "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None)
+    "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),
 }
 
 # static path

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -95,7 +95,8 @@ extlinks = {
     "MI_docs": (
         "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
         None,
-    )
+    ),
+    "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None)
 }
 
 # static path

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -31,7 +31,7 @@ Check that you can start the PyGranta RecordLists client from Python by running 
 
     <RecordListsApiClient url: http://my.server.name/mi_servicelayer>
 
-See the OpenAPI-Common documentation for supported :OpenAPI-Common:`Authentication schemes <index.html#authentication-schemes>`.
+This example uses Windows-based autologon authentication. For all supported authentication schemes, see the :OpenAPI-Common:`OpenAPI-Common documentation <index.html#authentication-schemes>`.
 
 If you see a response from the server, you have successfully installed PyGranta RecordLists and
 can start using the RecordLists client. For more examples, see

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -31,6 +31,8 @@ Check that you can start the PyGranta RecordLists client from Python by running 
 
     <RecordListsApiClient url: http://my.server.name/mi_servicelayer>
 
+See the OpenAPI-Common documentation for supported :OpenAPI-Common:`Authentication schemes <index.html#authentication-schemes>`.
+
 If you see a response from the server, you have successfully installed PyGranta RecordLists and
 can start using the RecordLists client. For more examples, see
 :ref:`ref_grantami_recordlists_examples`. For comprehensive information on the API, see

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -6,3 +6,4 @@ Makefile
 jupytext
 (?i)ansys
 THIRDPARTY
+autologon


### PR DESCRIPTION
https://github.com/ansys/pygranta/issues/109

Adds a link to the OpenAPI-Common documentation, to the section that presents supported auth methods in a formatted table.