### PR TITLE
Improve VM management in CI

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -169,6 +169,7 @@ jobs:
           sphinxopts: "-n -W --keep-going"
 
   check_workflow_runs:
+    if: ${{ !cancelled() }}
     name: Check if there are active workflow runs
     needs: doc-build
     uses: ansys/pygranta/.github/workflows/check-concurrent-workflows.yml@main
@@ -177,7 +178,7 @@ jobs:
     name: "Stop Azure VM"
     runs-on: ubuntu-latest
     needs: check_workflow_runs
-    if: always() && !cancelled() && !(inputs.skip-vm-management) && needs.check_workflow_runs.outputs.active-runs != 'true'
+    if: ${{ !cancelled() && !(inputs.skip-vm-management) && needs.check_workflow_runs.outputs.active-runs != 'true' }}
     steps:
       - uses: azure/CLI@v2
         with:

--- a/doc/changelog.d/324.maintenance.md
+++ b/doc/changelog.d/324.maintenance.md
@@ -1,0 +1,1 @@
+Fix VM management conditions

--- a/doc/changelog.d/324.maintenance.md
+++ b/doc/changelog.d/324.maintenance.md
@@ -1,1 +1,1 @@
-Fix VM management conditions
+Improve VM management in CI


### PR DESCRIPTION
When integration tests failed, the job to check whether there are other active workflow runs was skipped and the VM was always turned off.
Adds a condition on the `check_workflow_runs` job to always run, unless the whole workflow has been cancelled, in which case the VM shutdown is also skipped.