### PR TITLE
Update Ansys documentation links to 2025 R1

### DIFF
--- a/doc/changelog.d/337.documentation.md
+++ b/doc/changelog.d/337.documentation.md
@@ -1,0 +1,1 @@
+Update Ansys documentation links to 2025 R1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -93,7 +93,7 @@ numpydoc_validation_checks = {
 
 extlinks = {
     "MI_docs": (
-        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/%s",
+        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v251/en/%s",
         None,
     ),
     "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -21,10 +21,9 @@ The record list management capability is available to users in the following fro
 However, since these front-ends all share a common implementation in Granta MI, record lists can be
 created, accessed, and modified in any front-end with full interoperability. The documentation in
 this package is only concerned with this package. For more information about the other
-tools mentioned in the preceding list, consult the :MI_docs:`Granta MI Favorites <One_MI_Favorites>`
-and :MI_docs:`Granta MI Materials Gateway for Ansys Workbench <Granta_MI_MG_Help_AWB>`
-documentation. Documentation is available for other Materials Gateway applications in the Ansys
-Help.
+tools mentioned in the preceding list, consult the :MI_docs:`Granta MI Favorites <One_MI_Favorites/index.html>`
+and :MI_docs:`Granta MI Materials Gateway <Materials_Gateway/index.html>`
+documentation.
 
 
 Record list operations
@@ -50,4 +49,4 @@ Granta MI configuration
 
 Any use of Granta MI requires the user to have permission to access the Granta MI Server. Some
 record lists operations require additional permissions specific to record lists. For more
-information, see the :MI_docs:`Granta MI Favorites <One_MI_Favorites>` documentation.
+information, see the :MI_docs:`Granta MI Favorites <One_MI_Favorites/index.html>` documentation.


### PR DESCRIPTION
Closes #336 

Update Ansys doc reference to v251. Changes were required to explicitly link to the index.html page (this may be an artifact of testing against the internal QA site), and linking to the new 'Gateway' help page, instead of for a specific host.