### PR TITLE
Use public 2024 R2 Ansys documentation

### DIFF
--- a/doc/changelog.d/340.documentation.md
+++ b/doc/changelog.d/340.documentation.md
@@ -1,0 +1,1 @@
+Use public 2024 R2 Ansys documentation

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -93,7 +93,7 @@ numpydoc_validation_checks = {
 
 extlinks = {
     "MI_docs": (
-        "https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v251/en/%s",
+        "https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/Granta/v242/en/%s",
         None,
     ),
     "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),


### PR DESCRIPTION
Closes #339 

Use the 2024 R2 public documentation site for core software documentation references.

We have to use the 2024 R2 documentation, because the 2025 R1 documentation will be released *after* this package.