### PR TITLE
Revert required MI version bump to 2024 R2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Dependencies
 ------------
 .. readme_software_requirements
 
-To use this version of the ``ansys.grantami.recordlists`` package you must have access to a Granta MI 2025 R1 deployment.
+To use this version of the ``ansys.grantami.recordlists`` package you must have access to a Granta MI 2024 R2 deployment.
 
 The ``ansys.grantami.recordlists`` package currently supports Python from version 3.10 to version 3.13.
 

--- a/doc/changelog.d/351.documentation.md
+++ b/doc/changelog.d/351.documentation.md
@@ -1,0 +1,1 @@
+Revert required MI version bump to 2024 R2


### PR DESCRIPTION
25R1 did not include changes to the record list API, so this version still only requires a 24R2 MI installation.