### PR TITLE
Bump version to 2.0.0.dev1

### DIFF
--- a/doc/changelog.d/364.maintenance.md
+++ b/doc/changelog.d/364.maintenance.md
@@ -1,0 +1,1 @@
+Bump version to 2.0.0.dev1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 # Check https://python-poetry.org/docs/pyproject/ for all available sections
 name = "ansys-grantami-recordlists"
-version = "2.0.0.dev0"
+version = "2.0.0.dev1"
 description = "A python wrapper for the Granta MI RecordLists API"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Bump version to 2.0.0.dev1 to be able to publish a build compatible with serverapi 5.0 to the private index.