### PR TITLE
Start Granta MI 2024 R1 test machine

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -88,6 +88,8 @@ jobs:
             url: "TEST_SERVER_25R1_URL"
           - name: "AZURE_VM_NAME_24R2"
             url: "TEST_SERVER_24R2_URL"
+          - name: "AZURE_VM_NAME_24R1"
+            url: "TEST_SERVER_24R1_URL"
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v4

--- a/doc/changelog.d/377.maintenance.md
+++ b/doc/changelog.d/377.maintenance.md
@@ -1,0 +1,1 @@
+Start Granta MI 2024 R1 test machine


### PR DESCRIPTION
PR #374 added tests against MI 2024 R1, but didn't start the machine. CI on that PR passed because the machine was already on.

This PR adds the additional machine to the "Start VM" job.