### PR TITLE
Handle missing Granta MI version for integration tests

### DIFF
--- a/doc/changelog.d/378.fixed.md
+++ b/doc/changelog.d/378.fixed.md
@@ -1,0 +1,1 @@
+Handle missing Granta MI version for integration tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,8 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def mi_version(request):
     mi_version: str = request.config.getoption("--mi-version")
+    if not mi_version:
+        return None
     parsed_version = mi_version.split(".")
     if len(parsed_version) != 2:
         raise ValueError("--mi-version argument must be a MAJOR.MINOR version number")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -81,71 +81,60 @@ def list_password_no_permissions() -> str:
 @pytest.fixture(scope="session")
 def admin_client(
     sl_url, list_admin_username, list_admin_password, list_name, mi_version
-) -> RecordListsApiClient | None:
+) -> RecordListsApiClient:
     """
     Fixture providing a real ApiClient to run integration tests against an instance of Granta MI
     Server API.
     On teardown, deletes all lists named using the fixture `list_name`.
-
-    If client cannot be created because an unsupported Granta MI version is under test, instead yield
-    None and skip teardown. Tests that rely on a client being successfully generated should be
-    skipped via the 'mi_version' argument to the integration mark.
     """
     connection = Connection(sl_url).with_credentials(list_admin_username, list_admin_password)
-
-    skip_teardown = False
     try:
         client = connection.connect()
     except ConnectionError as e:
         if mi_version not in _ClientFactory(Mock(spec=Connection))._client_map:
-            client = None
-            skip_teardown = True
+            pytest.skip(
+                f"Client not available for Granta MI v{'.'.join(str(v) for v in mi_version)}"
+            )
         else:
             raise e
 
     yield client
 
-    if not skip_teardown:
-        all_lists = client.get_all_lists()
-        for record_list in all_lists:
-            if list_name in record_list.name:
-                client.delete_list(record_list)
+    all_lists = client.get_all_lists()
+    for record_list in all_lists:
+        if list_name in record_list.name:
+            client.delete_list(record_list)
 
 
 @pytest.fixture(scope="session")
 def basic_client(
     sl_url, list_username_no_permissions, list_password_no_permissions, list_name, mi_version
-) -> RecordListsApiClient | None:
+) -> RecordListsApiClient:
     """
     Fixture providing a real ApiClient to run integration tests against an instance of Granta MI
     Server API.
     On teardown, deletes all lists named using the fixture `list_name`.
-
-    If client cannot be created because an unsupported Granta MI version is under test, instead yield
-    None and skip teardown. Tests that rely on a client being successfully generated should be
-    skipped via the 'mi_version' argument to the integration mark.
     """
     connection = Connection(sl_url).with_credentials(
         list_username_no_permissions,
         list_password_no_permissions,
     )
-    skip_teardown = False
     try:
         client = connection.connect()
     except ConnectionError as e:
         if mi_version not in _ClientFactory(Mock(spec=Connection))._client_map:
-            client = None
-            skip_teardown = True
+            pytest.skip(
+                f"Client not available for Granta MI v{'.'.join(str(v) for v in mi_version)}"
+            )
         else:
             raise e
 
     yield client
 
-    if not skip_teardown:
-        all_lists = client.get_all_lists()
-        for record_list in all_lists:
-            if list_name in record_list.name:
-                client.delete_list(record_list)
+    all_lists = client.get_all_lists()
+    for record_list in all_lists:
+        if list_name in record_list.name:
+            client.delete_list(record_list)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -769,8 +769,11 @@ def process_integration_marks(request, mi_version):
         return
 
     if mi_version is None:
-        # An MI version number was not provided
-        return
+        # We didn't get an MI version. If integration tests were requested, an MI version must be provided. Raise
+        # an exception to fail all integration tests.
+        raise ValueError(
+            "No Granta MI Version provided to pytest. Specify Granta MI version with --mi-version MAJOR.MINOR."
+        )
 
     # Process integration mark arguments
     mark: pytest.Mark = request.node.get_closest_marker("integration")


### PR DESCRIPTION
Improve the error message if integration tests are run and `--mi-version` is not provided