### PR TITLE
Fix 2025R2 integration tests

### DIFF
--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -252,7 +252,10 @@ class RecordCreator:
             compare_version_state(required_state, GsaVersionState.RELEASED)
             and required_version == 1
         ):
-            if self.latest_state == GsaVersionState.UNRELEASED.name and self.latest_version == 1:
+            if (
+                compare_version_state(self.latest_state, GsaVersionState.UNRELEASED)
+                and self.latest_version == 1
+            ):
                 self._release()
                 return self.latest_version_guid
 


### PR DESCRIPTION
I missed updating a version state equality check when I updated the code to support responses from different MI versions. This check was used to create records in various release states, which only happens if the record doesn't already exist. We hit it now because I just switched to use a fresh copy of the 2025 R2 MI Training database