### PR TITLE
Temporarily xfail broken 2025 R2 integration tests

### DIFF
--- a/doc/changelog.d/399.maintenance.md
+++ b/doc/changelog.d/399.maintenance.md
@@ -1,0 +1,1 @@
+Temporarily xfail broken 2025 R2 integration tests

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -591,7 +591,10 @@ class TestLifeCycleNewList(TestLifeCycle):
             admin_client.unpublish_list(new_list)
         assert e.value.status_code == 400
 
-    def test_cannot_reset(self, admin_client, new_list):
+    def test_cannot_reset(self, admin_client, new_list, request, mi_version):
+        if mi_version == (25, 2):
+            marker = pytest.mark.xfail(reason="MI-21534", strict=True)
+            request.node.add_marker(marker)
         with pytest.raises(ApiException, match=self._not_awaiting_approval_error) as e:
             admin_client.cancel_list_approval_request(new_list)
         assert e.value.status_code == 400
@@ -652,7 +655,10 @@ class TestLifeCyclePublishedAndNotAwaitingApproval(TestLifeCycle):
             admin_client.unpublish_list(new_list)
         assert e.value.status_code == 400
 
-    def test_cannot_reset(self, admin_client, new_list):
+    def test_cannot_reset(self, admin_client, new_list, request, mi_version):
+        if mi_version == (25, 2):
+            marker = pytest.mark.xfail(reason="MI-21534", strict=True)
+            request.node.add_marker(marker)
         with pytest.raises(ApiException, match=self._not_awaiting_approval_error) as e:
             admin_client.cancel_list_approval_request(new_list)
         assert e.value.status_code == 400


### PR DESCRIPTION
These tests are currently failing due to the issue included in the xfail reason.

This PR should be merged to ensure main is passing, and will need to be subsequently reverted once Granta MI is updated.