### PR TITLE
Clarify audit log search behavior

### DIFF
--- a/doc/changelog.d/401.documentation.md
+++ b/doc/changelog.d/401.documentation.md
@@ -1,0 +1,1 @@
+Clarify audit log search behavior

--- a/src/ansys/grantami/recordlists/_connection.py
+++ b/src/ansys/grantami/recordlists/_connection.py
@@ -746,7 +746,7 @@ class RecordListsApiClient(ApiClient):  # type: ignore[misc]
 
     def get_all_audit_log_entries(self, page_size: Optional[int] = 100) -> Iterator[AuditLogItem]:
         """
-        Fetch all audit log entries that are visible to the current user.
+        Fetch all audit log entries for all lists that are visible to the current user.
 
         Performs an HTTP request against the Granta MI Server API.
 
@@ -771,6 +771,9 @@ class RecordListsApiClient(ApiClient):  # type: ignore[misc]
     ) -> Iterator[AuditLogItem]:
         """
         Fetch audit log entries, filtered by a search criterion.
+
+        If the ``criterion`` parameter does not specify a list identifier, then the results will be limited to the lists
+        that are visible to the current user.
 
         Performs an HTTP request against the Granta MI Server API.
 

--- a/src/ansys/grantami/recordlists/_connection.py
+++ b/src/ansys/grantami/recordlists/_connection.py
@@ -770,10 +770,10 @@ class RecordListsApiClient(ApiClient):  # type: ignore[misc]
         self, criterion: AuditLogSearchCriterion, page_size: Optional[int] = 100
     ) -> Iterator[AuditLogItem]:
         """
-        Fetch audit log entries, filtered by a search criterion.
+        Fetch all audit log entries for all lists that are visible to the current user, filtered by a search criterion.
 
-        If the ``criterion`` parameter does not specify a list identifier, then the results will be limited to the lists
-        that are visible to the current user.
+        If the search criterion does not specify a list identifier, then all actions relating to deleted lists are
+        excluded.
 
         Performs an HTTP request against the Granta MI Server API.
 


### PR DESCRIPTION
Closes #385 

Clarify that unless a list identifier is specified, the audit log entries returned will be limited to the lists visible to the current user only.