### PR TITLE
Use PyPI-authored publish action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -205,6 +205,7 @@ jobs:
         name: "Release to GitHub"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
     name: "Deploy stable documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -195,11 +195,19 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: ansys/actions/release-pypi-public@v9
-        name: "Release to public PyPI"
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9
         with:
-          library-name: ${{ env.LIBRARY_NAME }}
-          use-trusted-publisher: true
+          name: ${{ env.LIBRARY_NAME }}-artifacts
+          path: ${{ env.LIBRARY_NAME }}-artifacts
+
+      - name: "Upload artifacts to PyPI using trusted publisher"
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
+          skip-existing: false
 
       - uses: ansys/actions/release-github@v9
         name: "Release to GitHub"

--- a/doc/changelog.d/405.maintenance.md
+++ b/doc/changelog.d/405.maintenance.md
@@ -1,0 +1,1 @@
+Use PyPI-authored publish action


### PR DESCRIPTION
Use PyPI-authored publish action, instead of the Ansys-wrapped version. 

Copied from https://actions.docs.ansys.com/version/stable/migrations/release-pypi-trusted-publisher.html#release-pypi-trusted-publisher
