### PR TITLE
Revert "Temporarily xfail broken 2025 R2 integration tests (#399)"

### DIFF
--- a/doc/changelog.d/399.maintenance.md
+++ b/doc/changelog.d/399.maintenance.md
@@ -1,1 +1,0 @@
-Temporarily xfail broken 2025 R2 integration tests

--- a/doc/changelog.d/408.maintenance.md
+++ b/doc/changelog.d/408.maintenance.md
@@ -1,0 +1,1 @@
+Revert "Temporarily xfail broken 2025 R2 integration tests (#399)"

--- a/doc/changelog.d/408.maintenance.md
+++ b/doc/changelog.d/408.maintenance.md
@@ -1,1 +1,0 @@
-Revert "Temporarily xfail broken 2025 R2 integration tests (#399)"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -591,10 +591,7 @@ class TestLifeCycleNewList(TestLifeCycle):
             admin_client.unpublish_list(new_list)
         assert e.value.status_code == 400
 
-    def test_cannot_reset(self, admin_client, new_list, request, mi_version):
-        if mi_version == (25, 2):
-            marker = pytest.mark.xfail(reason="MI-21534", strict=True)
-            request.node.add_marker(marker)
+    def test_cannot_reset(self, admin_client, new_list):
         with pytest.raises(ApiException, match=self._not_awaiting_approval_error) as e:
             admin_client.cancel_list_approval_request(new_list)
         assert e.value.status_code == 400
@@ -655,10 +652,7 @@ class TestLifeCyclePublishedAndNotAwaitingApproval(TestLifeCycle):
             admin_client.unpublish_list(new_list)
         assert e.value.status_code == 400
 
-    def test_cannot_reset(self, admin_client, new_list, request, mi_version):
-        if mi_version == (25, 2):
-            marker = pytest.mark.xfail(reason="MI-21534", strict=True)
-            request.node.add_marker(marker)
+    def test_cannot_reset(self, admin_client, new_list):
         with pytest.raises(ApiException, match=self._not_awaiting_approval_error) as e:
             admin_client.cancel_list_approval_request(new_list)
         assert e.value.status_code == 400


### PR DESCRIPTION
This reverts commit e0d193849f4d55cfe95b1c7a8ac80599b7ac47d5.

Manually delete generated changelog entry before merging.