### PR TITLE
Re-organize ApiClient hierarchy

### DIFF
--- a/doc/changelog.d/401.documentation.md
+++ b/doc/changelog.d/401.documentation.md
@@ -1,0 +1,1 @@
+Clarify audit log search behavior

--- a/doc/changelog.d/413.added.md
+++ b/doc/changelog.d/413.added.md
@@ -1,1 +1,1 @@
-First step at reworking hierarchy
+Re-organize ApiClient hierarchy

--- a/src/ansys/grantami/recordlists/_connection.py
+++ b/src/ansys/grantami/recordlists/_connection.py
@@ -201,7 +201,10 @@ class RecordListsApiClient(ApiClient, ABC):
     """
     Communicates with Granta MI.
 
-    This is an abstract class. Some methods in this class are not implemented by all Granta MI versions.
+    This is an abstract class. Each concrete subtype of this class corresponds to a specific Granta MI server version.
+
+    Methods are only implemented if the underlying functionality is supported by the Granta MI server version. If the
+    functionality is not available, a :class:`NotImplementedError` is raised.
     """
 
     _api: types.ModuleType
@@ -223,6 +226,11 @@ class RecordListsApiClient(ApiClient, ABC):
         self._instantiate_apis()
 
     def _instantiate_apis(self) -> None:
+        """Instantiate the APIs required by this class.
+
+        The versions of the API classes are not fixed, and depend on the api module defined in the ``_api`` class
+        variable. This method can be overridden if APIs do not exist for a certain Granta MI version.
+        """
         self.schema_api = self._api.SchemaApi(self)
         self.list_management_api = self._api.ListManagementApi(self)
         self.list_item_api = self._api.ListItemApi(self)
@@ -251,6 +259,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Get the details of all record lists available for the current user.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
 
         Returns
@@ -266,6 +276,8 @@ class RecordListsApiClient(ApiClient, ABC):
     def get_list(self, identifier: str) -> RecordList:
         """
         Get the details of a record list.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
 
@@ -288,6 +300,8 @@ class RecordListsApiClient(ApiClient, ABC):
     ) -> List[SearchResult]:
         """
         Search for record lists matching the provided criteria.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs multiple HTTP requests against the Server API.
 
@@ -328,6 +342,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Get all items included in a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
 
         Parameters
@@ -350,6 +366,8 @@ class RecordListsApiClient(ApiClient, ABC):
     ) -> List[RecordListItem]:
         """
         Get all resolvable items included in a record list.
+
+        This method is available for all supported versions of Granta MI.
 
         If an item cannot be resolved, it will not be returned. Performs multiple HTTP requests
         against the Granta MI Server API.
@@ -407,6 +425,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Add items to a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
         Items are not validated against existing records on the server or existing items in the
         list.
@@ -438,6 +458,8 @@ class RecordListsApiClient(ApiClient, ABC):
     ) -> List[RecordListItem]:
         """
         Remove items from a record list.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
         Attempting to remove items that are not in the list will not result in an error.
@@ -473,6 +495,8 @@ class RecordListsApiClient(ApiClient, ABC):
     ) -> RecordList:
         """
         Create a new record list with the provided arguments.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
 
@@ -512,6 +536,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Delete a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
 
         Parameters
@@ -532,6 +558,8 @@ class RecordListsApiClient(ApiClient, ABC):
     ) -> RecordList:
         """
         Update a record list with the provided arguments.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
 
@@ -579,6 +607,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Create a copy of a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API. The resulting list has a name
         prefixed by the original list name.
 
@@ -600,6 +630,8 @@ class RecordListsApiClient(ApiClient, ABC):
     def revise_list(self, record_list: RecordList) -> RecordList:
         """
         Revise a record list.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
         Revising a list allows a user to create a personal copy of a published list and to modify
@@ -627,6 +659,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Request approval for a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
         Requesting approval updates the ``awaiting approval`` status of the record list to ``True``.
 
@@ -650,6 +684,8 @@ class RecordListsApiClient(ApiClient, ABC):
     def publish_list(self, record_list: RecordList) -> RecordList:
         """
         Publish a record list.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
         The list must be awaiting approval and not published already. Publishing the list updates
@@ -678,6 +714,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Withdraw a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
         The list must be published and awaiting approval. Withdrawing the list updates
         the *published* status to False and resets the awaiting approval status.
@@ -704,6 +742,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Cancel a pending request for approval on a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
         The list must be awaiting approval. Cancelling the approval request resets the awaiting
         approval status to False.
@@ -729,6 +769,8 @@ class RecordListsApiClient(ApiClient, ABC):
         """
         Subscribe the current user to a record list.
 
+        This method is available for all supported versions of Granta MI.
+
         Performs an HTTP request against the Granta MI Server API.
         The list must be published.
 
@@ -746,6 +788,8 @@ class RecordListsApiClient(ApiClient, ABC):
     def unsubscribe_from_list(self, record_list: RecordList) -> None:
         """
         Unsubscribe the current user from a record list.
+
+        This method is available for all supported versions of Granta MI.
 
         Performs an HTTP request against the Granta MI Server API.
 
@@ -783,6 +827,11 @@ class RecordListsApiClient(ApiClient, ABC):
         -------
         Iterator of :class:`.AuditLogItem`
             Audit log entries.
+
+        Raises
+        ------
+        NotImplementedError
+            If this method is not supported by the Granta MI server.
         """
         pass
 
@@ -814,6 +863,11 @@ class RecordListsApiClient(ApiClient, ABC):
         -------
         Iterator of :class:`.AuditLogItem`
             Audit log entries.
+
+        Raises
+        ------
+        NotImplementedError
+            If this method is not supported by the Granta MI server.
         """
         pass
 
@@ -902,10 +956,14 @@ class _RecordListsApiClient2025R1(RecordListsApiClient):
         super().__init__(session, service_layer_url, configuration)
 
     def _instantiate_apis(self) -> None:
-        self.schema_api = v2025r1api.SchemaApi(self)
-        self.list_management_api = v2025r1api.ListManagementApi(self)
-        self.list_item_api = v2025r1api.ListItemApi(self)
-        self.list_permissions_api = v2025r1api.ListPermissionsApi(self)
+        """Override the base implementation of this module.
+
+        This is required because ``AuditLogApi`` is not available in the 2025 R1 definition.
+        """
+        self.schema_api = self._api.SchemaApi(self)
+        self.list_management_api = self._api.ListManagementApi(self)
+        self.list_item_api = self._api.ListItemApi(self)
+        self.list_permissions_api = self._api.ListPermissionsApi(self)
         self.list_audit_log_api = None
 
     def search_for_lists(
@@ -933,20 +991,20 @@ class _RecordListsApiClient2025R1(RecordListsApiClient):
         ]
 
     def get_all_audit_log_entries(self, page_size: Optional[int] = 100) -> Iterator[AuditLogItem]:
-        raise NotImplementedError(
-            "This method is only supported when using Granta MI 2025 R2 or later."
-        )
+        raise NotImplementedError("This method is only supported by Granta MI 2025 R2 or later.")
 
     def search_for_audit_log_entries(
         self, criterion: AuditLogSearchCriterion, page_size: Optional[int] = 100
     ) -> Iterator[AuditLogItem]:
-        raise NotImplementedError(
-            "This method is only supported when using Granta MI 2025 R2 or later."
-        )
+        raise NotImplementedError("This method is only supported by Granta MI 2025 R2 or later.")
 
 
 class _RecordListsApiClient2024R2(RecordListsApiClient):
-    """2024 R2 implementation of the RecordListsApiClient interface."""
+    """2024 R2 implementation of the RecordListsApiClient interface.
+
+    This module uses the 2025 R1 definition of Server API and model classes. The 2025 R1 Server API bindings are
+    identical to the 2024 R2 Server API bindings for RecordList-related APIs.
+    """
 
     _api = v2025r1api
     _models = v2025r1models
@@ -961,10 +1019,14 @@ class _RecordListsApiClient2024R2(RecordListsApiClient):
         super().__init__(session, service_layer_url, configuration)
 
     def _instantiate_apis(self) -> None:
-        self.schema_api = v2025r1api.SchemaApi(self)
-        self.list_management_api = v2025r1api.ListManagementApi(self)
-        self.list_item_api = v2025r1api.ListItemApi(self)
-        self.list_permissions_api = v2025r1api.ListPermissionsApi(self)
+        """Override the base implementation of this module.
+
+        This is required because ``AuditLogApi`` is not available in the 2024 R2 definition.
+        """
+        self.schema_api = self._api.SchemaApi(self)
+        self.list_management_api = self._api.ListManagementApi(self)
+        self.list_item_api = self._api.ListItemApi(self)
+        self.list_permissions_api = self._api.ListPermissionsApi(self)
         self.list_audit_log_api = None
 
     def search_for_lists(
@@ -992,16 +1054,12 @@ class _RecordListsApiClient2024R2(RecordListsApiClient):
         ]
 
     def get_all_audit_log_entries(self, page_size: Optional[int] = 100) -> Iterator[AuditLogItem]:
-        raise NotImplementedError(
-            "This method is only supported when using Granta MI 2025 R2 or later."
-        )
+        raise NotImplementedError("This method is only supported by Granta MI 2025 R2 or later.")
 
     def search_for_audit_log_entries(
         self, criterion: AuditLogSearchCriterion, page_size: Optional[int] = 100
     ) -> Iterator[AuditLogItem]:
-        raise NotImplementedError(
-            "This method is only supported when using Granta MI 2025 R2 or later."
-        )
+        raise NotImplementedError("This method is only supported by Granta MI 2025 R2 or later.")
 
 
 class _ItemResolver:
@@ -1135,8 +1193,7 @@ class Connection(ApiClientFactory):
     For advanced usage, including configuring session-specific properties and timeouts, see the
     :external+openapi-common:doc:`ansys-openapi-common API reference <api/index>`. Specifically, see
     the documentation for the :class:`~ansys.openapi.common.ApiClientFactory` base class and the
-    :class:`~ansys.openapi.common.SessionConfiguration` class
-
+    :class:`~ansys.openapi.common.SessionConfiguration` class.
 
     1. Create the connection builder object and specify the server to connect to.
     2. Specify the authentication method to use for the connection and provide credentials if
@@ -1183,8 +1240,9 @@ class Connection(ApiClientFactory):
         Returns
         -------
         :class:`.RecordListsApiClient`
-            Client object that can be used to connect to Granta MI and interact with the record
-            list API.
+            Client object that can be used to connect to Granta MI and interact with the record list API. The client
+            object is a subtype of :class:`.RecordListsApiClient`. The subtype returned depends on the Granta MI server
+            version.
         """
         self._validate_builder()
         client_factory = _ClientFactory(self)

--- a/src/ansys/grantami/recordlists/_connection.py
+++ b/src/ansys/grantami/recordlists/_connection.py
@@ -833,7 +833,6 @@ class RecordListsApiClient(ApiClient, ABC):
         NotImplementedError
             If this method is not supported by the Granta MI server.
         """
-        pass
 
     @abstractmethod
     def search_for_audit_log_entries(
@@ -869,7 +868,6 @@ class RecordListsApiClient(ApiClient, ABC):
         NotImplementedError
             If this method is not supported by the Granta MI server.
         """
-        pass
 
 
 class _RecordListsApiClient2025R2(RecordListsApiClient):

--- a/src/ansys/grantami/recordlists/_connection.py
+++ b/src/ansys/grantami/recordlists/_connection.py
@@ -762,7 +762,7 @@ class RecordListsApiClient(ApiClient):
 
     def get_all_audit_log_entries(self, page_size: Optional[int] = 100) -> Iterator[AuditLogItem]:
         """
-        Fetch all audit log entries that are visible to the current user.
+        Fetch all audit log entries for all lists that are visible to the current user.
 
         Performs an HTTP request against the Granta MI Server API.
 
@@ -786,7 +786,10 @@ class RecordListsApiClient(ApiClient):
         self, criterion: AuditLogSearchCriterion, page_size: Optional[int] = 100
     ) -> Iterator[AuditLogItem]:
         """
-        Fetch audit log entries, filtered by a search criterion.
+        Fetch all audit log entries for all lists that are visible to the current user, filtered by a search criterion.
+
+        If the search criterion does not specify a list identifier, then all actions relating to deleted lists are
+        excluded.
 
         Performs an HTTP request against the Granta MI Server API.
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -40,28 +40,45 @@ from ansys.grantami.recordlists import (
     UserOrGroup,
     UserRole,
 )
-from ansys.grantami.recordlists._connection import RecordLists2025R12024R2ApiClient
+from ansys.grantami.recordlists._connection import (
+    _RecordListsApiClient2024R2,
+    _RecordListsApiClient2025R1,
+    _RecordListsApiClient2025R2,
+)
 
 pytestmark = pytest.mark.integration(mi_versions=[(25, 2), (25, 1), (24, 2)])
 
 
 class TestConnection:
     @pytest.mark.integration(mi_versions=[(25, 2)])
-    def test_latest_mi_version(self, sl_url, list_admin_username, list_admin_password):
+    def test_mi_25_2(self, sl_url, list_admin_username, list_admin_password):
         connection = Connection(sl_url).with_credentials(list_admin_username, list_admin_password)
         client = connection.connect()
         assert isinstance(client, RecordListsApiClient)
-        assert not isinstance(client, RecordLists2025R12024R2ApiClient)
+        assert isinstance(client, _RecordListsApiClient2025R2)
+        assert not isinstance(client, _RecordListsApiClient2025R1)
+        assert not isinstance(client, _RecordListsApiClient2024R2)
 
-    @pytest.mark.integration(mi_versions=[(25, 1), (24, 2)])
-    def test_older_supported_mi_version(self, sl_url, list_admin_username, list_admin_password):
+    @pytest.mark.integration(mi_versions=[(25, 1)])
+    def test_mi_25_1(self, sl_url, list_admin_username, list_admin_password):
         connection = Connection(sl_url).with_credentials(list_admin_username, list_admin_password)
         client = connection.connect()
         assert isinstance(client, RecordListsApiClient)
-        assert isinstance(client, RecordLists2025R12024R2ApiClient)
+        assert not isinstance(client, _RecordListsApiClient2025R2)
+        assert isinstance(client, _RecordListsApiClient2025R1)
+        assert not isinstance(client, _RecordListsApiClient2024R2)
+
+    @pytest.mark.integration(mi_versions=[(24, 2)])
+    def test_mi_24_2(self, sl_url, list_admin_username, list_admin_password):
+        connection = Connection(sl_url).with_credentials(list_admin_username, list_admin_password)
+        client = connection.connect()
+        assert isinstance(client, RecordListsApiClient)
+        assert not isinstance(client, _RecordListsApiClient2025R2)
+        assert not isinstance(client, _RecordListsApiClient2025R1)
+        assert isinstance(client, _RecordListsApiClient2024R2)
 
     @pytest.mark.integration(mi_versions=[(24, 1)])
-    def test_unsupported_mi_version(self, sl_url, list_admin_username, list_admin_password):
+    def test_mi_24_1_not_supported(self, sl_url, list_admin_username, list_admin_password):
         # We don't raise the expected version-specific error message because the Server API location has moved since
         # 2024 R1 was released.
         connection = Connection(sl_url).with_credentials(list_admin_username, list_admin_password)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1304,7 +1304,6 @@ class TestBooleanSearch(_TestSearch):
         assert {list_personal.identifier, list_published.identifier} == ids
 
 
-@pytest.mark.integration(mi_versions=[(25, 2)])
 class TestAuditLogging:
     _name_suffix_A = "_ListA"
     _name_suffix_B = "_ListB"
@@ -1327,6 +1326,7 @@ class TestAuditLogging:
         unpublished_list = admin_client.unpublish_list(requested_list)
         admin_client.delete_list(unpublished_list)
 
+    @pytest.mark.integration(mi_versions=[(25, 2)])
     @pytest.mark.skip(reason="Current performance and network issues with getting all lists")
     def test_get_all_log_entries(self, admin_client, list_a, list_b):
         log_entries = admin_client.get_all_audit_log_entries(page_size=100)
@@ -1338,6 +1338,7 @@ class TestAuditLogging:
             assert isinstance(result.initiating_user, UserOrGroup)
             _ = uuid.UUID(result.initiating_user.identifier)
 
+    @pytest.mark.integration(mi_versions=[(25, 2)])
     @pytest.mark.parametrize("paged", (True, False))
     def test_filter_log_entries_by_list(self, admin_client, list_a, list_b, paged):
         criterion = AuditLogSearchCriterion(filter_record_lists=[list_a.identifier])
@@ -1350,6 +1351,7 @@ class TestAuditLogging:
         assert results[0].list_identifier == list_a.identifier
         assert results[0].action == AuditLogAction.LISTCREATED
 
+    @pytest.mark.integration(mi_versions=[(25, 2)])
     def test_filter_log_entries_by_list_is_ordered(self, admin_client, list_a, list_b):
         criterion = AuditLogSearchCriterion(filter_record_lists=[list_b.identifier])
         results = list(admin_client.search_for_audit_log_entries(criterion))
@@ -1363,3 +1365,20 @@ class TestAuditLogging:
         ]
         for event, action in zip(results, expected_actions):
             assert event.action == action
+
+    @pytest.mark.integration(mi_versions=[(25, 1), (24, 2)])
+    def test_search_for_audit_log_entries_not_implemented(self, admin_client):
+        criterion = AuditLogSearchCriterion()
+        with pytest.raises(
+            NotImplementedError,
+            match="This method is only supported by Granta MI 2025 R2 or later.",
+        ):
+            admin_client.search_for_audit_log_entries(criterion)
+
+    @pytest.mark.integration(mi_versions=[(25, 1), (24, 2)])
+    def test_test_get_all_log_entries_not_implemented(self, admin_client):
+        with pytest.raises(
+            NotImplementedError,
+            match="This method is only supported by Granta MI 2025 R2 or later.",
+        ):
+            admin_client.get_all_audit_log_entries()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from types import SimpleNamespace
-from typing import Any, Type
+from typing import Any
 from unittest.mock import Mock
 import uuid
 
@@ -48,15 +48,17 @@ import pytest
 from ansys.grantami.recordlists import (
     RecordList,
     RecordListItem,
-    RecordListsApiClient,
     SearchResult,
 )
-from ansys.grantami.recordlists._connection import PROXY_PATH
+from ansys.grantami.recordlists._connection import (
+    PROXY_PATH,
+    _RecordListsApiClient2025R2,
+)
 
 
 @pytest.fixture
-def client():
-    client = RecordListsApiClient(
+def client(request):
+    client = _RecordListsApiClient2025R2(
         session=Mock(),
         service_layer_url="http://server_name/mi_servicelayer",
         configuration=Mock(),
@@ -76,19 +78,20 @@ def test_client_has_expected_api_url(client):
     assert client.api_url == "http://server_name/mi_servicelayer" + PROXY_PATH
 
 
-def test_client_repr(client):
-    assert repr(client) == "<RecordListsApiClient url: http://server_name/mi_servicelayer>"
+def test_client_25r2_repr(client):
+    assert repr(client) == "<_RecordListsApiClient2025R2 url: http://server_name/mi_servicelayer>"
 
 
 class TestClientMethod:
     _return_value: Any
-    _api: Type
+    _api_name: str
     _api_method: str
     _mock_uuid = str(uuid.uuid4())
 
     @pytest.fixture
     def api_method(self, monkeypatch):
         mocked_method = Mock(return_value=self._return_value)
+
         monkeypatch.setattr(self._api, self._api_method, mocked_method)
         return mocked_method
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -30,7 +30,9 @@ from ansys.grantami.recordlists import Connection, RecordListsApiClient
 from ansys.grantami.recordlists._connection import (
     AUTH_PATH,
     PROXY_PATH,
-    RecordLists2025R12024R2ApiClient,
+    _RecordListsApiClient2024R2,
+    _RecordListsApiClient2025R1,
+    _RecordListsApiClient2025R2,
 )
 
 
@@ -89,10 +91,12 @@ def test_new_server_version(sl_url, successful_auth, mocker):
         mocker.get(requests_mock.ANY, status_code=200, json=mi_version_response)
         client = connection.connect()
     assert isinstance(client, RecordListsApiClient)
-    assert not isinstance(client, RecordLists2025R12024R2ApiClient)
+    assert isinstance(client, _RecordListsApiClient2025R2)
+    assert not isinstance(client, _RecordListsApiClient2025R1)
+    assert not isinstance(client, _RecordListsApiClient2024R2)
 
 
-def test_old_supported_server_version(sl_url, successful_auth, mocker):
+def test_old_supported_server_version_25_1(sl_url, successful_auth, mocker):
     mi_version_response = {
         "binaryCompatibilityVersion": "25.1.0.0",
         "version": "25.1.820.0",
@@ -103,8 +107,29 @@ def test_old_supported_server_version(sl_url, successful_auth, mocker):
         connection = Connection(sl_url).with_anonymous()
         mocker.get(requests_mock.ANY, status_code=200, json=mi_version_response)
         client = connection.connect()
+
     assert isinstance(client, RecordListsApiClient)
-    assert isinstance(client, RecordLists2025R12024R2ApiClient)
+    assert not isinstance(client, _RecordListsApiClient2025R2)
+    assert isinstance(client, _RecordListsApiClient2025R1)
+    assert not isinstance(client, _RecordListsApiClient2024R2)
+
+
+def test_old_supported_server_version_24_2(sl_url, successful_auth, mocker):
+    mi_version_response = {
+        "binaryCompatibilityVersion": "24.2.0.0",
+        "version": "24.2.820.0",
+        "majorMinorVersion": "24.2",
+    }
+
+    with mocker:
+        connection = Connection(sl_url).with_anonymous()
+        mocker.get(requests_mock.ANY, status_code=200, json=mi_version_response)
+        client = connection.connect()
+
+    assert isinstance(client, RecordListsApiClient)
+    assert not isinstance(client, _RecordListsApiClient2025R2)
+    assert not isinstance(client, _RecordListsApiClient2025R1)
+    assert isinstance(client, _RecordListsApiClient2024R2)
 
 
 def test_old_unsupported_server_version_is_handled(sl_url, successful_auth, mocker):


### PR DESCRIPTION
Closes #412 
Closes #411 
Closes #410 

Convert `RecordListsApiClient` into an abstract class, and create private concrete implementations for each supported Granta MI version. This makes the implementation more explicit, providing a direct mapping between Granta MI version and client class definition. Each class then contains the model and api module as class variables, which are then used to instantiate the class and required APIs.

The abstract class defines all public methods and provides docstrings. It also documents which Granta MI versions are supported for each method.

If a method is implemented for all supported versions, then the 'current' implementation is included in the abstract class. If the implementation is the same for all versions, it can be inherited directly. If the implementation is different for a specific versions, it can be overriden in that client class.

If a method is not implemented for all classes, then it is defined as an abstract class. It is then implemented in the clients that support it, and raises a NotImplementedError in clients that don't. This provides a tangible improvement over the current behavior, where unsupported APIs would raise a null-reference AttributeError instead.

This approach is optimized towards additions to the clients with new versions. This may prove to be suboptimal with future developments, but all the concrete classes are private and not documented, so this approach can be revised if needed.