### PR TITLE
Improve documentation for Granta MI version support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,8 @@ Dependencies
 ------------
 .. readme_software_requirements
 
-To use this version of the ``ansys.grantami.recordlists`` package you must have access to a Granta MI 2024 R2 deployment.
+This version of the ``ansys.grantami.recordlists`` package requires Granta MI 2024 R2 or newer. To find a version of
+this package compatible with older versions of Granta MI, see `the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions.html/>`_.
 
 The ``ansys.grantami.recordlists`` package currently supports Python from version 3.10 to version 3.13.
 

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,9 @@ Dependencies
 ------------
 .. readme_software_requirements
 
-This version of the ``ansys.grantami.recordlists`` package requires Granta MI 2024 R2 or newer. To find a version of
-this package compatible with older versions of Granta MI, see `the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions.html/>`_.
+This version of the ``ansys.grantami.recordlists`` package requires Granta MI 2024 R2 or newer. Use
+`the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions.html/>`_ to find the
+version of this package compatible with older Granta MI versions.
 
 The ``ansys.grantami.recordlists`` package currently supports Python from version 3.10 to version 3.13.
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Dependencies
 .. readme_software_requirements
 
 This version of the ``ansys.grantami.recordlists`` package requires Granta MI 2024 R2 or newer. Use
-`the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions.html/>`_ to find the
+`the PyGranta documentation <https://grantami.docs.pyansys.com/version/stable/package_versions>`_ to find the
 version of this package compatible with older Granta MI versions.
 
 The ``ansys.grantami.recordlists`` package currently supports Python from version 3.10 to version 3.13.

--- a/doc/changelog.d/415.documentation.md
+++ b/doc/changelog.d/415.documentation.md
@@ -1,0 +1,1 @@
+Improve version support documentation

--- a/doc/changelog.d/415.documentation.md
+++ b/doc/changelog.d/415.documentation.md
@@ -1,1 +1,1 @@
-Improve version support documentation
+Improve documentation for Granta MI version support


### PR DESCRIPTION
Closes #414 

Refer to the improved PyGranta metapackage documentation for guidance on how to determine package compatibility for unsupported Granta MI versions.

The link points to the version table page, which is updated as part of https://github.com/ansys/pygranta/pull/175