### PR TITLE
Add integration checks completeness step at CI top-level

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -153,6 +153,15 @@ jobs:
     secrets:
       inherit
 
+  integration-checks-complete:
+    name: "Integration checks complete"
+    runs-on: ubuntu-latest
+    if: always() && ( startsWith( github.event.pull_request.head.ref, 'dependabot/') || needs.server-checks.result == 'success' )
+    needs: server-checks
+    steps:
+      - name: "Integration checks complete"
+        run: echo "Integration checks complete"
+
   doc-deploy-dev:
     name: "Deploy development documentation"
     runs-on: ubuntu-latest

--- a/doc/changelog.d/423.maintenance.md
+++ b/doc/changelog.d/423.maintenance.md
@@ -1,0 +1,1 @@
+Add integration checks completeness step at CI top-level


### PR DESCRIPTION
Closes #404 
Adds an extra step to check whether integration checks have successfully run or have been skipped for dependabot PRs.
I've updated required checks to include the new step, the build-library step, and all unit tests steps.