### PR TITLE
Update changelog with link to stable docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 This project uses [towncrier](https://towncrier.readthedocs.io/) to generate changelogs.
 
-The changes for the upcoming release can be found in
+Changes for releases after 1.0.0 can be found in
+<https://recordlists.grantami.docs.pyansys.com/version/stable/changelog.html>.
+
+Changes for the upcoming release can be found in
 <https://github.com/ansys/grantami-recordlists/tree/main/doc/changelog.d/>.
 
 


### PR DESCRIPTION
Closes #460 

Adds a link to the changelog.md file to point to the new changelog section of the HTML documentation.